### PR TITLE
Unnest rtlcss config

### DIFF
--- a/config/rtlcss.js
+++ b/config/rtlcss.js
@@ -43,15 +43,13 @@ module.exports = {
 				},
 			],
 		},
-		plugin: {
-			expand: true,
-			cwd: "<%= paths.css %>",
-			src: [
-				"**/*.css",
-				"!**/*-rtl.css",
-			],
-			dest: "<%= paths.css %>",
-			ext: "-rtl.css",
-		},
+		expand: true,
+		cwd: "<%= paths.css %>",
+		src: [
+			"**/*.css",
+			"!**/*-rtl.css",
+		],
+		dest: "<%= paths.css %>",
+		ext: "-rtl.css",
 	}
 };


### PR DESCRIPTION
The `rtlcss` config is nested inside an unknown `plugin` key. Likely copied over from a setup that ran `rtlcss:plugin`. As it's now already nested in the `build` key in order to run `rtlcss:build` it should no longer be nested in the `plugin` key.