### PR TITLE
Fixes the regex replacing one of the version numbers in the pluginMainFile

### DIFF
--- a/config/update-version.js
+++ b/config/update-version.js
@@ -24,7 +24,7 @@ module.exports = {
 	},
 	initializer: {
 		options: {
-			regEx: /(define\( \'<%= pluginVersionConstant %>\'\, \')(\d+(\.\d+){0,3})([^\.^\'\d]?.*?)(\' \);\n)/,
+			regEx: "(define\\( '<%= pluginVersionConstant %>'\\, \\')(\\d+(\\.\\d+){0,3})([^\\.^\\'\\d]?.*?)(\\' \\);\\n)",
 			preVersionMatch: "$1",
 			postVersionMatch: "$5",
 		},

--- a/tasks/update-version.js
+++ b/tasks/update-version.js
@@ -19,9 +19,12 @@ module.exports = function( grunt ) {
 			);
 
 			this.files.forEach( ( file ) => {
+				// If options.regEx is a string, create a regex from it. If it's already a regex, use it as is.
+				const regex = ( typeof options.regEx === 'string' ) ? new RegExp ( options.regEx ) : options.regEx;
+
 				file.src.forEach( ( path ) => {
 					let contents = grunt.file.read( path ).replace(
-						options.regEx,
+						regex,
 						options.preVersionMatch + options.version + options.postVersionMatch
 					);
 					grunt.file.write( path, contents );


### PR DESCRIPTION
## Summary
- Fixes a bug where the initializer regex in the update version config would never match.
- The update-version tasks now accepts both strings and regexes in `options.regEx`.

## Technical choices
- Before, <%= pluginVersionConstant %> was literally matched by the regex, which is incorrect.  Now, it's actually replaced by the pluginVersionConstant before the regex matches. In order to do so, the regex needed to be created using `new RegExp()`. Regexes created with // can't have dynamic content. Because we're now dealing with two types of regex formats in the config (strings and regexes with //), the task needed to be modified as well. This change also secures backward compatibility with other plugins using this repo.
- Strings passed to `new RegExp()` need different escaping. That's where the extra slashes are coming from 😉.

## Test instructions
### News SEO
- Link this branch to `release/11.7` of News SEO.
- Run `composer install` and `yarn install` in both repos.
- Run `grunt set-version --new-version=12.3-RC4` in News.
- Run `grunt update-version` in News.
- Check that all version mentions have been updated to `12.3-RC4`, especially https://github.com/Yoast/wpseo-news/blob/trunk/wpseo-news.php#L40.

### wordpress-seo
- Link this branch to `release/11.7` of wordpress-seo.
- Run `composer install` and `yarn install` in both repos.
- Run `grunt set-version --new-version=12.3-RC4` in wordpress-seo.
- Run `grunt update-version` in wordpress-seo.
- Check that all version mentions have been updated to `12.3-RC4`.

When everything is okay, release a new version of this repo, and bump the versions in wordpress-seo and News SEO.

Fixes https://github.com/Yoast/wpseo-news/issues/516