### PR TITLE
Add version bump regex to update stable version in README.md

### DIFF
--- a/config/update-version.js
+++ b/config/update-version.js
@@ -12,6 +12,14 @@ module.exports = {
 		},
 		src: "readme.txt",
 	},
+	readmeMd: {
+		options: {
+			regEx: /(Stable tag:\s+)(\d+(\.\d+){0,3})([^\n^\.\d]?.*?)(\n)/,
+			preVersionMatch: "$1",
+			postVersionMatch: "$5",
+		},
+		src: "README.md",
+	},
 
 	// When changing or adding entries, make sure to update `aliases.yml` for "update-version-trunk".
 	pluginFile: {


### PR DESCRIPTION
Before this change, the stable version was only bumped if it was in the readme.txt. This PR make sure the stable version will also be bumped if it's in the README.md.

Fixes https://github.com/Yoast/wpseo-news/issues/526