### PR TITLE
Update command for phpcs

### DIFF
--- a/config/shell.js
+++ b/config/shell.js
@@ -33,7 +33,10 @@ module.exports = function( grunt ) {
 		},
 
 		"phpcs": {
-			command: "php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+			command: "if [[ -f \"./vendor/squizlabs/php_codesniffer/bin/phpcs\"]]; " +
+					 "then php ./vendor/squizlabs/php_codesniffer/bin/phpcs" +
+					 "else php ./vendor/squizlabs/php_codesniffer/scripts/phpcs " +
+					 "fi",
 		}
 	};
 };

--- a/config/shell.js
+++ b/config/shell.js
@@ -33,7 +33,7 @@ module.exports = function( grunt ) {
 		},
 
 		"phpcs": {
-			command: "php ./vendor/squizlabs/php_codesniffer/scripts/phpcs",
+			command: "php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
 		}
 	};
 };


### PR DESCRIPTION
I've updated the content of the `shell:phpcs` command. 

A couple of plugins is using and older version of the yoastcs package and for these the command will work. 

For plugins using a newer version of the yoastcs package it might not work. This is because of the `squizlabs/php_codesniffer` that have moved the phpcs executable from scripts to the bin directory. 

We have to update the package version of this for some plugins like wpseo-woocommerce when this `plugin-grunt-tasks` is updated.