### PR TITLE
Don't use .min anymore

### DIFF
--- a/config/rtlcss.js
+++ b/config/rtlcss.js
@@ -46,9 +46,9 @@ module.exports = {
 		cwd: "<%= paths.css %>",
 		src: [
 			"**/*.css",
-			"!**/*-rtl<%= developmentBuild ? '' : '.min' %>.css",
+			"!**/*-rtl.css",
 		],
 		dest: "<%= paths.css %>",
-		ext: "-rtl<%= developmentBuild ? '' : '.min' %>.css",
+		ext: "-rtl.css",
 	},
 };


### PR DESCRIPTION
We don't use `.min` anymore so we shouldn't use that for RTL files either.