### PR TITLE
Release/1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1940,6 +1940,9 @@ grunt.initConfig( {
 
 ## Release History
 
+### 1.6.2
+- Bump version of `grunt-contrib-compress` to add node 12 support.
+
 ### 1.6.1
 - No longer use `.min` when generating RTL CSS files to be consistent with non-RTL files.
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"grunt": "^1.0.4",
 		"grunt-checktextdomain": "^1.0.1",
 		"grunt-contrib-clean": "~1.0.0",
-		"grunt-contrib-compress": "^1.5.0",
+		"grunt-contrib-compress": "^1.6.0",
 		"grunt-contrib-copy": "^1.0.0",
 		"grunt-contrib-cssmin": "^3.0.0",
 		"grunt-contrib-imagemin": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@yoast/grunt-plugin-tasks",
 	"description": "Custom Yoast grunt tasks",
-	"version": "1.6.1",
+	"version": "1.6.2",
 	"homepage": "https://github.com/Yoast/",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary
Bumps `grunt-contrib-compress` to version `^1.6.0` which adds Node v12 support.