### PR TITLE
Watch improvements

### DIFF
--- a/config/watch.js
+++ b/config/watch.js
@@ -3,6 +3,18 @@ module.exports = {
 	options: {
 		livereload: true,
 	},
+	grunt: {
+		options: {
+			reload: true,
+		},
+		files: [
+			"<%= files.grunt %>",
+			"<%= files.config %>",
+		],
+		tasks: [
+			"eslint:grunt",
+		],
+	},
 	js: {
 		files: [
 			"<%= files.js %>",

--- a/config/watch.js
+++ b/config/watch.js
@@ -15,20 +15,4 @@ module.exports = {
 			"eslint:grunt",
 		],
 	},
-	js: {
-		files: [
-			"<%= files.js %>",
-		],
-		tasks: [
-			"build:js",
-		],
-	},
-	css: {
-		files: [
-			"<%= files.sass %>",
-		],
-		tasks: [
-			"build:css",
-		],
-	},
 };


### PR DESCRIPTION
## Removed JS & CSS configuration

As we don't have to have JS or CSS in any of the plugins, having this configuration requires each plugin to overwrite or work-around these configs if they don't.

Having an empty configuration value (for files.sass) will break the watch command and have it stuck in an unending loop.

This configuration should be added in each plugin anyway, to have a better understanding of which files are being watched and what checks are performed when they are being changed.

Note that PHP is missing from this configuration to begin with.

**Note that this is a breaking change** as plugins need to add their own `watch.js` to make sure their assets are watched as expected.

## Added Grunt config file watching
The files that are always present are the grunt-configuration files, which need to be checked with ESLint upon changes.
These files are added to the watch configuration.