### PR TITLE
Makepot: exclude directories

### DIFF
--- a/config/makepot.js
+++ b/config/makepot.js
@@ -11,7 +11,10 @@ module.exports = {
 				'last-translator': '<%= pkg.pot.lasttranslator %>'
 			},
 			type: 'wp-plugin',
-			exclude: []
+			exclude: [
+				"<%= files.artifact %>",
+				".wordpress-svn",
+			]
 		}
 	}
 };


### PR DESCRIPTION
Artifact and WordPress SVN checkout should be excluded from POT file generation. Otherwise a lot of duplicates will be found.