### PR TITLE
ADD  function to use our changelog generator to update the changelogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2469,7 +2469,7 @@ update-changelog-to-latest: {
             pluginSlug: "wordpress-seo",
             defaultChangelogEntries: "",
             useANewLineAfterHeader: true,
-            
+            changelogToInject: ".tmp/currentitems.txt"
             commitChangelog: false,
         },
     },

--- a/README.md
+++ b/README.md
@@ -2324,8 +2324,164 @@ get-latest-pr-texts: {
     },
 }
 ```
+### The `update-changelog-to-latest` task
+#### Using our configuration
+We implement the following configuration:
+- `options`
+    - The `options.pluginSlug` value is  from the Grunt configuration: `pluginSlug`.
+    - The `options.commitChangelog` value is set to `true`,
+    - The `options.useANewLineAfterHeader` value is set to `true`,
+	- The `options.defaultChangelogEntries` value is set to `""`,
+	- The `options.daysToAddForNextRelease` value is set to `14`,
+    - The `options.useTodayasReleaseDate` value is set to  `false`,
+    - The `options.changelogToInject`value is set to  `""`,
+
+#### Overview
+In your project's Gruntfile, add a section named `update-changelog-to-latest` to the data object passed into `grunt.initConfig()`.
+```js
+grunt.initConfig( {
+    update-changelog-to-latest: {
+        options: {},     // Global options.
+        taskName: {      // The name of your task.
+            options: {}, // Task-specific options.
+        }
+    }
+} )
+```
+
+#### Options
+##### pluginSlug
+Type: `String`  
+Default value: ``
+
+
+##### commitChangelog
+Type: `Boolean`  
+Default: `false`
+
+Setting this to `true` will commit the changes made to git.
+
+##### readmeFile
+Type: `String`  
+Default value: null
+
+The source and destination file to update the changelog section in.
+
+##### releaseInChangelog
+Type: `String`  
+Default value: null
+
+Regular expression to match the correct changelog section.
+
+_Note: `VERSIONNUMBER` will be replaced by a dynamic value_
+
+##### matchChangelogHeader
+Type: `String`  
+Default value: null
+
+Regular expression to match the correct the header.
+
+_Note: `VERSIONNUMBER` will be replaced by a dynamic value_
+
+##### newHeadertemplate
+Type: `String`  
+Default value: null
+
+Template used to create a new changelog header.
+
+_Note: Both `VERSIONNUMBER` and `DATESTRING` will be replaced by dynamic values_
+
+##### matchCorrectHeader
+Type: `String`  
+Default value: null
+
+Regular expression to match the correct header in the changelog section.
+
+_Note: `VERSIONNUMBER` will be replaced by a dynamic value_
+
+##### matchCorrectLines
+Type: `String`  
+Default value: null
+
+Regular expression to match the correct lines in the changelog section.
+
+_Note: `VERSIONNUMBER` will be replaced by a dynamic value_
+
+##### matchCleanedChangelog
+Type: `String`  
+Default value: null
+
+Regular expression to match the cleaned (removed older entries) changelog section.
+
+_Note: `VERSIONNUMBER` will be replaced by a dynamic value_
+
+##### replaceCleanedChangelog
+Type: `String`  
+Default value: null
+
+Regular expression to replace the cleaned (removed older entries) changelog section with the new.
+
+##### defaultChangelogEntries
+Type: `String`  
+Default value: `""`
+
+Optional value to add default entries to a new created section.
+
+_Note: `VERSIONNUMBER` will be replaced by a dynamic value_
+
+##### useANewLineAfterHeader
+Type: `Boolean`  
+Default: `true`
+
+Setting this will effect the format of the resulting changelog.
+
+##### daysToAddForNextRelease
+Type: `Integer`
+Default: `14`
+
+Setting this will effect the release date guessing to pick the next tuesday after 7 days before 14 (if default is used).
+
+##### useTodayasReleaseDate:
+Type `Boolean`
+Default: `false`
+
+Setting this will set the release date (if not already set) to today
+
+##### changelogToInject
+Type: `String`  
+Default value: `""`
+
+Setting this will replace the items whith the file content in the changelog
+
+##### Usages Example
+```js
+update-changelog-to-latest: {
+    "wordpress-seo": {
+        options: {
+            readmeFile: "./readme.txt",
+            releaseInChangelog: /[=] \d+\.\d+(\.\d+)? =/g,
+            matchChangelogHeader:  /[=]= Changelog ==\n\n/ig,
+            newHeadertemplate: "== Changelog ==\n\n" +"= " + "VERSIONNUMBER" + " =\nRelease Date: " + "DATESTRING"  + "\n\n",
+            matchCorrectHeader: "= " + "VERSIONNUMBER" + "(.|\\n)*?\\n(?=(\\w\+?:\\n|= \\d+[\.\\d]+ =|= Earlier versions =))",
+            matchCorrectLines: "= " + "VERSIONNUMBER" + "(.|\\n)*?(?=(= \\d+[\.\\d]+ =|= Earlier versions =))",
+            matchCleanedChangelog: "= " + "VERSIONNUMBER" + "(.|\\n)*= Earlier versions =",
+            replaceCleanedChangelog: "= Earlier versions =",
+            pluginSlug: "wordpress-seo",
+            defaultChangelogEntries: "",
+            useANewLineAfterHeader: true,
+            
+            commitChangelog: false,
+        },
+    },
+}
+```
+
+
 
 ## Release History
+
+### 2.3
+- Adds `update-changelog-to-latest` Grunt task & config.
 
 ### 2.2.1
 - FIXES a issue with `update-changelog-with-latest-pr-texts.js` selecting the todays date on a hotfix. 

--- a/config/update-changelog-to-latest.js
+++ b/config/update-changelog-to-latest.js
@@ -1,0 +1,8 @@
+// Custom task
+module.exports = {
+	options: {
+		useEditDistanceCompare: true,
+		pluginSlug: "<%= pluginSlug %>",
+		commitChangelog: true,
+	},
+};

--- a/config/update-changelog-to-latest.js
+++ b/config/update-changelog-to-latest.js
@@ -1,7 +1,6 @@
 // Custom task
 module.exports = {
 	options: {
-		useEditDistanceCompare: true,
 		pluginSlug: "<%= pluginSlug %>",
 		commitChangelog: true,
 	},

--- a/tasks/update-changelog-to-latest.js
+++ b/tasks/update-changelog-to-latest.js
@@ -1,0 +1,207 @@
+/* eslint-disable max-len */
+/* eslint-disable complexity */
+const parseVersion = require( "../lib/parse-version" );
+const _isEmpty = require( "lodash/isEmpty" );
+const escapeRegExp = require( "../lib/escape-regexp" );
+
+
+/**
+ * A task to remove old changelog entries and add new ones in changlog file..
+ *
+ * @param {Object} grunt The grunt helper object.
+ * @returns {void}
+ */
+module.exports = function( grunt ) {
+	grunt.registerMultiTask(
+		"update-changelog-to-latest",
+		"updates the changelog file with data retreived from changelog generator (n8n)",
+		// eslint-disable-next-line complexity
+		// eslint-disable-next-line max-statements
+		function() {
+			const options = this.options( {
+				commitChangelog: false,
+				useANewLineAfterHeader: true,
+				defaultChangelogEntries: "",
+				daysToAddForNextRelease: 14,
+				useTodayasReleaseDate: false,
+
+			} );
+			const done = this.async();
+			// Grab te XX.X only from XX.X-RCY/XX.X-betaY
+			const fullVersion = grunt.option( "plugin-version" );
+			const newVersion = fullVersion.split( "-" )[ 0 ];
+			if ( fullVersion.match( "beta" ) ) {
+				options.daysToAddForNextRelease = options.daysToAddForNextRelease + 7;
+			}
+			let useTodayasReleaseDate = false;
+			const versionNumber = parseVersion( newVersion );
+			const suffixes = {
+				one: "st",
+				two: "nd",
+				few: "rd",
+				other: "th",
+			};
+			const pr = new Intl.PluralRules( "en-US", {
+				type: "ordinal",
+			} );
+			/**
+	 		* Append suffix to number.
+	 		* @param {int} number changelogs to be parsed.
+	 		* @returns {string} number with suffix appended.
+	 		*/
+			const format = ( number ) => `${number}${suffixes[ pr.select( number ) ]}`;
+
+			let changelog = grunt.file.read( options.readmeFile );
+			const allReleasesInChangelog = changelog.match( options.releaseInChangelog );
+			const changelogVersions = allReleasesInChangelog.map(
+				element => parseVersion( element.slice( 2, element.length - 2 ) )
+			);
+			// Check if the current version already exists in the changelog.
+			const containsCurrentVersion = ! _isEmpty(
+				changelogVersions.filter( version => {
+					return (
+						versionNumber.major === version.major &&
+						versionNumber.minor === version.minor &&
+						versionNumber.patch === version.patch
+					);
+				} )
+			);
+
+			if ( versionNumber.patch !== 0 || options.useTodayasReleaseDate ) {
+				useTodayasReleaseDate = true;
+			}
+
+			// Only if the current version is not in the changelog yet, and is not a patch, we remove old changelog entries.
+			if ( ! containsCurrentVersion && versionNumber.patch === 0 ) {
+				let cleanedChangelog = changelog;
+				const highestMajor = Math.max( ...changelogVersions.map( version => version.major ) );
+				const lowestMajor = Math.min( ...changelogVersions.map( version => version.major ) );
+
+				if ( highestMajor === lowestMajor ) {
+					// If there are only multiple minor versions of the same major version, remove all entries from the oldest minor version.
+					const lowestMinor = Math.min( ...changelogVersions.map( version => version.minor ) );
+					const lowestVersion = `${lowestMajor}.${lowestMinor}`;
+					cleanedChangelog = changelog.replace(
+						new RegExp( options.matchCleanedChangelog.replace( new RegExp( "VERSIONNUMBER" ), escapeRegExp( lowestVersion ) ) ),
+						options.replaceCleanedChangelog
+					);
+				} else {
+					// If there are multiple major versions in the changelog, remove all entries from the oldest major version.
+					cleanedChangelog = changelog.replace(
+						new RegExp( options.matchCleanedChangelog.replace( new RegExp( "VERSIONNUMBER" ), escapeRegExp( lowestMajor ) ) ),
+						options.replaceCleanedChangelog
+					);
+				}
+
+				// If something has changed, persist this.
+				if ( cleanedChangelog !== changelog ) {
+					changelog = cleanedChangelog;
+
+					// Update the grunt reference to the changelog.
+					grunt.option( "changelog", changelog );
+
+					// Write changes to the file.
+					grunt.file.write( options.readmeFile, changelog );
+				}
+			}
+
+
+			// If the current version is already in the changelog.
+			if ( containsCurrentVersion ) {
+				// Get the changelog entries for the current version from the readme.
+				const changelogVersionNumber = versionNumber.major + "." + versionNumber.minor;
+				// eslint-disable-next-line max-len
+				const matchCorrectHeader =  options.matchCorrectHeader.replace( new RegExp( "VERSIONNUMBER" ), escapeRegExp( changelogVersionNumber ) );
+				const matchCorrectLines = options.matchCorrectLines.replace( new RegExp( "VERSIONNUMBER" ), escapeRegExp( changelogVersionNumber ) );
+				const currentChangelogEntriesMatches = changelog.match( new RegExp( matchCorrectLines ) );
+
+				var currentChangelogEntries = "";
+				if ( currentChangelogEntriesMatches ) {
+					currentChangelogEntries = `${currentChangelogEntriesMatches[ 0 ]}`;
+				}
+
+				// Get the header from the changelog entries
+
+				const currentChangelogEntriesHeaderMatches = changelog.match( new RegExp( matchCorrectHeader,  ) );
+				var currentChangelogEntriesHeader = "";
+				if ( currentChangelogEntriesHeaderMatches ) {
+					currentChangelogEntriesHeader = `${currentChangelogEntriesHeaderMatches[ 0 ]}`;
+				}
+
+				currentChangelogEntries = currentChangelogEntries.replace( new RegExp( escapeRegExp( currentChangelogEntriesHeader ) ), "" );
+
+				// Add n8n log here!!!
+				const n8nChangelog = grunt.file.read( "myn8nchangelogfile" );
+
+				// Put all parts togethor agian
+				// eslint-disable-next-line max-len
+				const mergedReadme = changelog.replace( new RegExp( escapeRegExp( currentChangelogEntriesHeader + currentChangelogEntries ) ),  currentChangelogEntriesHeader  + n8nChangelog );
+
+				// Write changes to the file.
+				grunt.file.write( options.readmeFile, mergedReadme );
+				done();
+			} else {
+				// If the current version is not in the changelog.
+
+				const n8nChangelog = grunt.file.read( "myn8nchangelogfile" );
+				// If the current version is not in the changelog, build a new one from input file.
+				let changelogVersionNumber = versionNumber.major + "." + versionNumber.minor;
+
+				// Only add the patch number if we're actually doing a patch.
+				if ( versionNumber.patch !== 0 ) {
+					changelogVersionNumber += "." + versionNumber.patch;
+				}
+				var d = new Date();
+				// Guess release date, probbaly next tuesday in two weeks time
+				// Options for better logic, get latest tag date
+				// Is date tag within 14 day next release 21 days
+				// If not next release 42 days
+				// Or login to jira get it there...
+
+
+				if ( useTodayasReleaseDate ) {
+					d.setDate(  d.getDate() );
+				} else {
+					d.setDate( d.getDate() + ( 2 + options.daysToAddForNextRelease - d.getDay() ) );
+				}
+				const ye = new Intl.DateTimeFormat( "en", { year: "numeric" } ).format( d );
+				const mo = new Intl.DateTimeFormat( "en", { month: "long" } ).format( d );
+				const da = new Intl.DateTimeFormat( "en", { day: "numeric" } ).format( d );
+				const datestring = `${mo} ${format( da )}, ${ye}`;
+				// eslint-disable-next-line max-len
+
+				var newChangelog = options.newHeadertemplate.replace( new RegExp( "VERSIONNUMBER" ), changelogVersionNumber );
+				newChangelog = newChangelog.replace( new RegExp( "DATESTRING" ), datestring ) + n8nChangelog;
+
+				// Add the changelog, behind the 'matched' header.
+				changelog = changelog.replace( options.matchChangelogHeader, newChangelog );
+				// Write changes to the file.
+				grunt.file.write( options.readmeFile, changelog );
+				done();
+			}
+
+			if ( options.commitChangelog ) {
+				// Stage the changed readme.txt.
+				grunt.config( "gitadd.addChangelog.files", { src: [ options.readmeFile ] } );
+				grunt.task.run( "gitadd:addChangelog" );
+
+				// Check if there is something to commit with `git status` first.
+				grunt.config( "gitstatus.checkChangelog.options.callback", function( changes ) {
+					// First character of the code checks the status in the index.
+					// eslint-disable-next-line max-len
+					const hasStagedChangelog = changes.some( change => change.code[ 0 ] !== " " && change.file === options.readmeFile.split( "/" )[ options.readmeFile.split( "/" ).length - 1 ] );
+
+					if ( hasStagedChangelog ) {
+						// Commit the changed readme.txt.
+						grunt.config( "gitcommit.commitChangelog.options.message", "Add changelog" );
+						grunt.task.run( "gitcommit:commitChangelog" );
+					} else {
+						grunt.log.writeln( "Changelog is unchanged. Nothing to commit." );
+					}
+				} );
+
+				grunt.task.run( "gitstatus:checkChangelog" );
+			}
+		}
+	);
+};

--- a/tasks/update-changelog-to-latest.js
+++ b/tasks/update-changelog-to-latest.js
@@ -107,7 +107,7 @@ module.exports = function( grunt ) {
 			}
 
 			if ( grunt.file.exists( options.changelogToInject ) ) {
-				grunt.log.writeln( "imput file not found" );
+				grunt.log.writeln( "input file not found" );
 				done();
 			}
 

--- a/tasks/update-changelog-to-latest.js
+++ b/tasks/update-changelog-to-latest.js
@@ -27,6 +27,7 @@ module.exports = function( grunt ) {
 				changelogToInject: "",
 			} );
 			const done = this.async();
+
 			// Grab te XX.X only from XX.X-RCY/XX.X-betaY
 			const fullVersion = grunt.option( "plugin-version" );
 			const newVersion = fullVersion.split( "-" )[ 0 ];
@@ -105,8 +106,14 @@ module.exports = function( grunt ) {
 				}
 			}
 
+			if ( grunt.file.exists( options.changelogToInject ) ) {
+				grunt.log.writeln( "imput file not found" );
+				done();
+			}
+
 			// Add n8n log here!!!
 			const n8nChangelog = grunt.file.read( options.changelogToInject );
+
 
 			// If the current version is already in the changelog.
 			if ( containsCurrentVersion ) {
@@ -174,6 +181,7 @@ module.exports = function( grunt ) {
 				changelog = changelog.replace( options.matchChangelogHeader, newChangelog );
 				// Write changes to the file.
 				grunt.file.write( options.readmeFile, changelog );
+
 				done();
 			}
 

--- a/tasks/update-changelog-to-latest.js
+++ b/tasks/update-changelog-to-latest.js
@@ -24,7 +24,7 @@ module.exports = function( grunt ) {
 				defaultChangelogEntries: "",
 				daysToAddForNextRelease: 14,
 				useTodayasReleaseDate: false,
-
+				changelogToInject: "",
 			} );
 			const done = this.async();
 			// Grab te XX.X only from XX.X-RCY/XX.X-betaY
@@ -105,6 +105,8 @@ module.exports = function( grunt ) {
 				}
 			}
 
+			// Add n8n log here!!!
+			const n8nChangelog = grunt.file.read( options.changelogToInject );
 
 			// If the current version is already in the changelog.
 			if ( containsCurrentVersion ) {
@@ -130,8 +132,6 @@ module.exports = function( grunt ) {
 
 				currentChangelogEntries = currentChangelogEntries.replace( new RegExp( escapeRegExp( currentChangelogEntriesHeader ) ), "" );
 
-				// Add n8n log here!!!
-				const n8nChangelog = grunt.file.read( "myn8nchangelogfile" );
 
 				// Put all parts togethor agian
 				// eslint-disable-next-line max-len
@@ -141,9 +141,6 @@ module.exports = function( grunt ) {
 				grunt.file.write( options.readmeFile, mergedReadme );
 				done();
 			} else {
-				// If the current version is not in the changelog.
-
-				const n8nChangelog = grunt.file.read( "myn8nchangelogfile" );
 				// If the current version is not in the changelog, build a new one from input file.
 				let changelogVersionNumber = versionNumber.major + "." + versionNumber.minor;
 

--- a/tasks/update-changelog-to-latest.js
+++ b/tasks/update-changelog-to-latest.js
@@ -114,7 +114,6 @@ module.exports = function( grunt ) {
 			// Add n8n log here!!!
 			const n8nChangelog = grunt.file.read( options.changelogToInject );
 
-
 			// If the current version is already in the changelog.
 			if ( containsCurrentVersion ) {
 				// Get the changelog entries for the current version from the readme.
@@ -138,7 +137,6 @@ module.exports = function( grunt ) {
 				}
 
 				currentChangelogEntries = currentChangelogEntries.replace( new RegExp( escapeRegExp( currentChangelogEntriesHeader ) ), "" );
-
 
 				// Put all parts togethor agian
 				// eslint-disable-next-line max-len

--- a/test/expected/changelog.md
+++ b/test/expected/changelog.md
@@ -1,4 +1,4 @@
-### 16.0: December 14th, 2021
+### 16.0: March 29th, 2022
 Enhancements:
 * test left over entry.
 

--- a/test/expected/changelog.md
+++ b/test/expected/changelog.md
@@ -1,4 +1,4 @@
-### 16.0: March 29th, 2022
+### 16.0: April 5th, 2022
 Enhancements:
 * test left over entry.
 

--- a/test/expected/changelog3.md
+++ b/test/expected/changelog3.md
@@ -1,4 +1,4 @@
-### 16.0: March 29th, 2022
+### 16.0: April 5th, 2022
 Bugfixes:
 
 * Fixes a bug where the word 'minute/minutes' would be in the user language, instead of the site language, for the estimated reading time block in the frontend.

--- a/test/expected/changelog3.md
+++ b/test/expected/changelog3.md
@@ -1,0 +1,20 @@
+### 16.0: March 29th, 2022
+
+Bugfixes:
+
+* Fixes a bug where the word 'minute/minutes' would be in the user language, instead of the site language, for the estimated reading time block in the frontend.
+
+Other:
+
+* Bumps the minimum required Yoast SEO version to 18.4.
+* Sets minimum required WordPress version to 5.8. 
+
+
+### 15.9: February 23rd, 2021
+Enhancements:
+* Improves performance for loading redirects.
+* Fixes possible misinterpretations or deprecation errors in the redirect manager due to an outdated SQL operator.
+
+Other:
+* Includes every change in Yoast SEO core 15.9. See the [core changelog](https://wordpress.org/plugins/wordpress-seo/#developers).
+

--- a/test/expected/changelog3.md
+++ b/test/expected/changelog3.md
@@ -1,5 +1,4 @@
 ### 16.0: March 29th, 2022
-
 Bugfixes:
 
 * Fixes a bug where the word 'minute/minutes' would be in the user language, instead of the site language, for the estimated reading time block in the frontend.

--- a/test/expected/changelog4.md
+++ b/test/expected/changelog4.md
@@ -1,0 +1,19 @@
+### 16.0: March 29th, 2022
+Bugfixes:
+
+* Fixes a bug where the word 'minute/minutes' would be in the user language, instead of the site language, for the estimated reading time block in the frontend.
+
+Other:
+
+* Bumps the minimum required Yoast SEO version to 18.4.
+* Sets minimum required WordPress version to 5.8. 
+
+
+### 15.9: February 23rd, 2021
+Enhancements:
+* Improves performance for loading redirects.
+* Fixes possible misinterpretations or deprecation errors in the redirect manager due to an outdated SQL operator.
+
+Other:
+* Includes every change in Yoast SEO core 15.9. See the [core changelog](https://wordpress.org/plugins/wordpress-seo/#developers).
+

--- a/test/expected/readme.txt
+++ b/test/expected/readme.txt
@@ -235,7 +235,7 @@ Your question has most likely been answered on our help center: [yoast.com/help/
 == Changelog ==
 
 = 16.0 =
-Release Date: December 14th, 2021
+Release Date: March 29th, 2022
 
 Bugfixes:
 

--- a/test/expected/readme.txt
+++ b/test/expected/readme.txt
@@ -235,7 +235,7 @@ Your question has most likely been answered on our help center: [yoast.com/help/
 == Changelog ==
 
 = 16.0 =
-Release Date: March 29th, 2022
+Release Date: April 5th, 2022
 
 Bugfixes:
 

--- a/test/expected/readme4.txt
+++ b/test/expected/readme4.txt
@@ -235,7 +235,7 @@ Your question has most likely been answered on our help center: [yoast.com/help/
 == Changelog ==
 
 = 16.7 =
-Release Date: March 29th, 2022
+Release Date: April 5th, 2022
 
 Enhancements:
 

--- a/test/expected/readme4.txt
+++ b/test/expected/readme4.txt
@@ -235,7 +235,7 @@ Your question has most likely been answered on our help center: [yoast.com/help/
 == Changelog ==
 
 = 16.7 =
-Release Date: December 14th, 2021
+Release Date: March 29th, 2022
 
 Enhancements:
 

--- a/test/fixtures/changelog3.md
+++ b/test/fixtures/changelog3.md
@@ -1,0 +1,30 @@
+### 15.9: February 23rd, 2021
+Enhancements:
+* Improves performance for loading redirects.
+* Fixes possible misinterpretations or deprecation errors in the redirect manager due to an outdated SQL operator.
+
+Other:
+* Includes every change in Yoast SEO core 15.9. See the [core changelog](https://wordpress.org/plugins/wordpress-seo/#developers).
+
+### 15.8.2: February 12th, 2021
+Bugfixes:
+* Fixes a bug where JavaScript and CSS files were missing for customers who downloaded 15.8.1 immediately after it was released.
+
+### 15.8.1: February 12th, 2021
+Bugfixes:
+* Fixes a bug where no Zapier API key would be generated when enabling the Zapier integration.
+
+### 15.8: February 10th, 2021
+Say hi to Yoast SEO 15.8! This release comes with a brand-new breadcrumbs block for the block editor. Try it out and guide your users - and Google! Read more about what’s new in Yoast SEO 15.8 in [our release post](https://yoa.st/release-15-8)!
+
+Enhancements:
+* You no longer have to type your name and email address when you send a support request via the HelpScout beacon. They’re taken from your WordPress profile.
+
+Bugfixes:
+* Fixes a bug where the wrong HelpScout beacon would load, thus not showing an ‘Ask’ option.
+* Fixes a bug where the Estimated Reading Time icon placeholder would be output as `ICON_PLACEHOLDER` when the post content was rendered directly, for example in a Latest Posts block. The icon is no longer visible when the post content is rendered directly.
+
+Other:
+* Includes every change in Yoast SEO core 15.8. See the [core changelog](https://wordpress.org/plugins/wordpress-seo/#developers).
+
+

--- a/test/fixtures/changelog4.md
+++ b/test/fixtures/changelog4.md
@@ -6,6 +6,7 @@ Bugfixes:
 Other:
 
 * Sets minimum required WordPress version to 5.8. 
+* Some wrong text here
 
 ### 15.9: February 23rd, 2021
 Enhancements:

--- a/test/fixtures/changelog4.md
+++ b/test/fixtures/changelog4.md
@@ -1,0 +1,17 @@
+### 16.0: March 29th, 2022
+Bugfixes:
+
+* Fiexes a bug where the word 'minute/minutes' would be in the user language, instead of the site language, for the estimated reading time block in the frontend.
+
+Other:
+
+* Sets minimum required WordPress version to 5.8. 
+
+### 15.9: February 23rd, 2021
+Enhancements:
+* Improves performance for loading redirects.
+* Fixes possible misinterpretations or deprecation errors in the redirect manager due to an outdated SQL operator.
+
+Other:
+* Includes every change in Yoast SEO core 15.9. See the [core changelog](https://wordpress.org/plugins/wordpress-seo/#developers).
+

--- a/test/fixtures/n8nchangelog.txt
+++ b/test/fixtures/n8nchangelog.txt
@@ -1,4 +1,3 @@
-
 Bugfixes:
 
 * Fixes a bug where the word 'minute/minutes' would be in the user language, instead of the site language, for the estimated reading time block in the frontend.

--- a/test/fixtures/n8nchangelog.txt
+++ b/test/fixtures/n8nchangelog.txt
@@ -1,0 +1,11 @@
+
+Bugfixes:
+
+* Fixes a bug where the word 'minute/minutes' would be in the user language, instead of the site language, for the estimated reading time block in the frontend.
+
+Other:
+
+* Bumps the minimum required Yoast SEO version to 18.4.
+* Sets minimum required WordPress version to 5.8. 
+
+

--- a/test/update-changelog-5-test.js
+++ b/test/update-changelog-5-test.js
@@ -1,0 +1,99 @@
+/* eslint-disable no-useless-escape */
+/* eslint-disable no-useless-concat */
+/**
+ * A unit test for 'set-version.js'.
+ *
+ * Copies the fixtures to the temp folder and runs set-version.
+ * After that the (fixture) files in the temp folder get compared with the expected folder.
+ */
+
+
+const grunt = require( "grunt" );
+const runTask = require( "grunt-run-task" );
+const tempFilePath = [ "tmp/changelog3.md" ];
+const expectedFilePath = [ "test/expected/changelog3.md" ];
+const srcWikimdfile = "test/fixtures/n8nchangelog.txt";
+const dstWikimdfile = "./.tmp/n8nchangelog.txt";
+const noOfFiles = Math.min( tempFilePath.length, expectedFilePath.length );
+let ChanceLogTask;
+
+exports.testChangeLog7Command = {
+	/**
+	 * @param {function} done Function to execute when done.
+	 * @returns {void}
+	 */
+	setUp: function( done ) {
+		// Load the tasks so they can be run
+		runTask.loadTasks( "tasks" );
+		// Setup the file's to run the test on
+		for ( let i = 0; i < noOfFiles; i++ ) {
+			const fixturePath = expectedFilePath[ i ].replace( "expected", "fixtures" );
+			grunt.log.writeln( "\n [" + ( i + 1 ) + "/" + noOfFiles + "] Copying '" + fixturePath + "' to '" + tempFilePath[ i ] + "'" );
+			grunt.file.copy( fixturePath, tempFilePath[ i ] );
+		}
+		grunt.file.mkdir( "./tmp" );
+		grunt.file.copy( srcWikimdfile, dstWikimdfile );
+		grunt.log.writeln( "setup is done!" );
+
+		runTask.option( "plugin-version", "16.0" );
+		ChanceLogTask = runTask.task( "update-changelog-to-latest", {
+			"wordpress-seo-premium": {
+				options: {
+					// Premium header:
+					// ### 15.9: February 23rd, 2021
+					readmeFile: "tmp/changelog3.md",
+					changelogToInject: "./.tmp/n8nchangelog.txt",
+					releaseInChangelog: /[#] \d+\.\d+(\.\d+)?\: /g,
+					matchChangelogHeader: /^/ig,
+					newHeadertemplate: "### " + "VERSIONNUMBER" + ": " + "DATESTRING"  + "\n",
+					matchCorrectLines: "### " + "VERSIONNUMBER" + "(.|\\n)*?(?=(### \\d+[\.\\d]+\: |$))",
+					matchCorrectHeader: "### " + "VERSIONNUMBER" + "(.|\\n)*?\\n(?=(\\w\+?:\\n|### \\d+[\.\\d]+\: |$))",
+					matchCleanedChangelog: "### " + "VERSIONNUMBER" + "(.|\\n)*$",
+					replaceCleanedChangelog: "",
+					pluginSlug: "wordpress-seo-premium",
+					// eslint-disable-next-line max-len
+					defaultChangelogEntries: "Other:\n* Includes every change in Yoast SEO core " + "VERSIONNUMBER" + ". See the [core changelog](https://wordpress.org/plugins/wordpress-seo/#developers).\n",
+					useANewLineAfterHeader: false,
+					commitChangelog: false,
+				},
+			},
+		} );
+
+		ChanceLogTask.run( function() {
+			done();
+		} );
+	},
+	/**
+	 * @param {object} test Test object
+	 * @returns {void}
+	 */
+	testChanceLogtask: function( test ) {
+		/**
+		 * Runs the test assertions to verify the 2 files are identical if the files given as parameters exist.
+		 *
+		 * @param {string} file1 The file path to compare to file2.
+		 * @param {string} file2 The file path to compare to file1.
+		 *
+		 * @returns {void}.
+		 */
+		function compareFiles( file1, file2 ) {
+			if ( grunt.file.exists( file1 ) && grunt.file.exists( file2 ) ) {
+				const actual = grunt.file.read( file1 );
+				const expected = grunt.file.read( file2 );
+				test.deepEqual( actual, expected, "Compare the file '" + file1 + "' with '" + file2 + "'" );
+				return;
+			}
+			grunt.fail.warn( "Expected files not found" );
+		}
+
+		const task = "update-changelog-to-latest";
+		if ( grunt.task.exists( task ) ) {
+			for ( let i = 0; i < noOfFiles; i++ ) {
+				compareFiles( tempFilePath[ i ], expectedFilePath[ i ] );
+			}
+		} else {
+			grunt.fail.warn( "The task " + task + "does not exist" );
+		}
+		test.done();
+	},
+};

--- a/test/update-changelog-6-test.js
+++ b/test/update-changelog-6-test.js
@@ -1,0 +1,99 @@
+/* eslint-disable no-useless-escape */
+/* eslint-disable no-useless-concat */
+/**
+ * A unit test for 'set-version.js'.
+ *
+ * Copies the fixtures to the temp folder and runs set-version.
+ * After that the (fixture) files in the temp folder get compared with the expected folder.
+ */
+
+
+const grunt = require( "grunt" );
+const runTask = require( "grunt-run-task" );
+const tempFilePath = [ "tmp/changelog4.md" ];
+const expectedFilePath = [ "test/expected/changelog4.md" ];
+const srcWikimdfile = "test/fixtures/n8nchangelog.txt";
+const dstWikimdfile = "./.tmp/n8nchangelog.txt";
+const noOfFiles = Math.min( tempFilePath.length, expectedFilePath.length );
+let ChanceLogTask;
+
+exports.testChangeLog8Command = {
+	/**
+	 * @param {function} done Function to execute when done.
+	 * @returns {void}
+	 */
+	setUp: function( done ) {
+		// Load the tasks so they can be run
+		runTask.loadTasks( "tasks" );
+		// Setup the file's to run the test on
+		for ( let i = 0; i < noOfFiles; i++ ) {
+			const fixturePath = expectedFilePath[ i ].replace( "expected", "fixtures" );
+			grunt.log.writeln( "\n [" + ( i + 1 ) + "/" + noOfFiles + "] Copying '" + fixturePath + "' to '" + tempFilePath[ i ] + "'" );
+			grunt.file.copy( fixturePath, tempFilePath[ i ] );
+		}
+		grunt.file.mkdir( "./tmp" );
+		grunt.file.copy( srcWikimdfile, dstWikimdfile );
+		grunt.log.writeln( "setup is done!" );
+
+		runTask.option( "plugin-version", "16.0" );
+		ChanceLogTask = runTask.task( "update-changelog-to-latest", {
+			"wordpress-seo-premium": {
+				options: {
+					// Premium header:
+					// ### 15.9: February 23rd, 2021
+					readmeFile: "tmp/changelog4.md",
+					changelogToInject: "./.tmp/n8nchangelog.txt",
+					releaseInChangelog: /[#] \d+\.\d+(\.\d+)?\: /g,
+					matchChangelogHeader: /^/ig,
+					newHeadertemplate: "### " + "VERSIONNUMBER" + ": " + "DATESTRING"  + "\n",
+					matchCorrectLines: "### " + "VERSIONNUMBER" + "(.|\\n)*?(?=(### \\d+[\.\\d]+\: |$))",
+					matchCorrectHeader: "### " + "VERSIONNUMBER" + "(.|\\n)*?\\n(?=(\\w\+?:\\n|### \\d+[\.\\d]+\: |$))",
+					matchCleanedChangelog: "### " + "VERSIONNUMBER" + "(.|\\n)*$",
+					replaceCleanedChangelog: "",
+					pluginSlug: "wordpress-seo-premium",
+					// eslint-disable-next-line max-len
+					defaultChangelogEntries: "Other:\n* Includes every change in Yoast SEO core " + "VERSIONNUMBER" + ". See the [core changelog](https://wordpress.org/plugins/wordpress-seo/#developers).\n",
+					useANewLineAfterHeader: false,
+					commitChangelog: false,
+				},
+			},
+		} );
+
+		ChanceLogTask.run( function() {
+			done();
+		} );
+	},
+	/**
+	 * @param {object} test Test object
+	 * @returns {void}
+	 */
+	testChanceLogtask: function( test ) {
+		/**
+		 * Runs the test assertions to verify the 2 files are identical if the files given as parameters exist.
+		 *
+		 * @param {string} file1 The file path to compare to file2.
+		 * @param {string} file2 The file path to compare to file1.
+		 *
+		 * @returns {void}.
+		 */
+		function compareFiles( file1, file2 ) {
+			if ( grunt.file.exists( file1 ) && grunt.file.exists( file2 ) ) {
+				const actual = grunt.file.read( file1 );
+				const expected = grunt.file.read( file2 );
+				test.deepEqual( actual, expected, "Compare the file '" + file1 + "' with '" + file2 + "'" );
+				return;
+			}
+			grunt.fail.warn( "Expected files not found" );
+		}
+
+		const task = "update-changelog-to-latest";
+		if ( grunt.task.exists( task ) ) {
+			for ( let i = 0; i < noOfFiles; i++ ) {
+				compareFiles( tempFilePath[ i ], expectedFilePath[ i ] );
+			}
+		} else {
+			grunt.fail.warn( "The task " + task + "does not exist" );
+		}
+		test.done();
+	},
+};


### PR DESCRIPTION
passes 'grunt test'

passes test to create/update changelog entries on:
* worpress-seo
* wordpress-seo-premium
* wordpress-seo-local
* wpseo-woocommerce
* wpseo-news
* wpseo-video