### PR TITLE
Change name of artifact output

### DIFF
--- a/config/compress.js
+++ b/config/compress.js
@@ -2,7 +2,7 @@
 module.exports = {
 	artifact: {
 		options: {
-			archive: "artifact.zip",
+			archive: "<%= pluginSlug %>-<%= pluginVersion %>.zip",
 			level: 9,
 		},
 		files: [


### PR DESCRIPTION
`grunt artifact` now outputs an `artifact.zip` by default, this would change it to `<plugin-slug>-<plugin-version>.zip`, so `wordpress-seo-16.1.zip` for instance.